### PR TITLE
Improve build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Este repositório contém o código do aplicativo **Letra Viva**, um aplicativo 
 2. Clone este repositório e abra o projeto pelo Android Studio.
 3. Aguarde a sincronização do Gradle e conecte um dispositivo ou inicie um emulador.
 4. Utilize a opção **Run** do Android Studio para compilar e instalar o aplicativo.
+5. Caso os scripts `gradlew` não estejam presentes, execute `gradle wrapper` para gerá-los.
+6. Crie um projeto no Firebase e coloque o arquivo `google-services.json` em `app/`. Atualize também o valor de `default_web_client_id` em `app/src/main/res/values/strings.xml`.
 
 Para compilar via linha de comando você também pode executar:
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,15 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
-    id 'com.google.gms.google-services'
+}
+
+// At build time Firebase requires `google-services.json`. To allow compilation
+// without the file we apply the plugin conditionally. Features that rely on
+// Firebase will only work when the configuration file is present.
+if (rootProject.file("app/google-services.json").exists()) {
+    apply plugin: 'com.google.gms.google-services'
+} else {
+    logger.warn("google-services.json not found. Firebase services will be disabled.")
 }
 
 android {


### PR DESCRIPTION
## Summary
- allow building app without a `google-services.json`
- clarify README with steps for Gradle wrapper and Firebase config

## Testing
- `gradle --version`


------
https://chatgpt.com/codex/tasks/task_e_685ddb611f408327842d7f08303f3049