### PR TITLE
Add Firestore integration for reading plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ O módulo principal fica em `app/` e segue a organização padrão de um aplicat
 - `model/` – modelos de dados utilizados no app
 - `util/` – constantes e utilidades diversas
 
+## Integração com banco gratuito na nuvem
+
+Este projeto utiliza o **Firebase Firestore** como exemplo de banco de dados na
+nuvem. O serviço possui um plano gratuito que permite testes iniciais sem custos.
+
+1. Acesse o [console do Firebase](https://console.firebase.google.com/) e crie
+   um projeto.
+2. Habilite o Firestore no modo *test* para facilitar os primeiros passos.
+3. Crie uma coleção chamada `plans` contendo documentos com o campo `title`.
+4. Copie o arquivo `google-services.json` gerado para o diretório `app/` do
+   projeto.
+
+O fragmento `PlanosFragment` carrega os planos diretamente do Firestore por meio
+da classe `PlanosViewModel`. Ajuste a coleção conforme a necessidade do seu
+aplicativo.
+
 ## Licença
 
 Este projeto é distribuído sem uma licença específica. Utilize o código de acordo com as boas práticas de software livre.

--- a/app/src/main/java/br/com/valenstech/letraviva/ui/planos/PlanosFragment.kt
+++ b/app/src/main/java/br/com/valenstech/letraviva/ui/planos/PlanosFragment.kt
@@ -5,14 +5,17 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import br.com.valenstech.letraviva.databinding.FragmentPlanosBinding
-import br.com.valenstech.letraviva.model.ReadingPlan
+import br.com.valenstech.letraviva.viewmodel.PlanosViewModel
 
 class PlanosFragment : Fragment() {
 
     private var _binding: FragmentPlanosBinding? = null
     private val binding get() = _binding!!
+    private lateinit var viewModel: PlanosViewModel
+    private lateinit var adapter: PlansAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -20,13 +23,16 @@ class PlanosFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentPlanosBinding.inflate(inflater, container, false)
-        val plans = listOf(
-            ReadingPlan("Plano 1"),
-            ReadingPlan("Plano 2"),
-            ReadingPlan("Plano 3")
-        )
+        adapter = PlansAdapter(emptyList())
         binding.recyclerPlans.layoutManager = LinearLayoutManager(requireContext())
-        binding.recyclerPlans.adapter = PlansAdapter(plans)
+        binding.recyclerPlans.adapter = adapter
+
+        viewModel = ViewModelProvider(this)[PlanosViewModel::class.java]
+        viewModel.plans.observe(viewLifecycleOwner) { plans ->
+            adapter.updatePlans(plans)
+        }
+        viewModel.loadPlans()
+
         return binding.root
     }
 

--- a/app/src/main/java/br/com/valenstech/letraviva/ui/planos/PlansAdapter.kt
+++ b/app/src/main/java/br/com/valenstech/letraviva/ui/planos/PlansAdapter.kt
@@ -5,10 +5,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import br.com.valenstech.letraviva.R
 import br.com.valenstech.letraviva.model.ReadingPlan
 
-class PlansAdapter(private val plans: List<ReadingPlan>) : RecyclerView.Adapter<PlansAdapter.PlanViewHolder>() {
+class PlansAdapter(private var plans: List<ReadingPlan>) : RecyclerView.Adapter<PlansAdapter.PlanViewHolder>() {
+
+    fun updatePlans(newPlans: List<ReadingPlan>) {
+        plans = newPlans
+        notifyDataSetChanged()
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PlanViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(android.R.layout.simple_list_item_1, parent, false)

--- a/app/src/main/java/br/com/valenstech/letraviva/viewmodel/PlanosViewModel.kt
+++ b/app/src/main/java/br/com/valenstech/letraviva/viewmodel/PlanosViewModel.kt
@@ -1,0 +1,30 @@
+package br.com.valenstech.letraviva.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import br.com.valenstech.letraviva.model.ReadingPlan
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+class PlanosViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val _plans = MutableLiveData<List<ReadingPlan>>()
+    val plans: LiveData<List<ReadingPlan>> = _plans
+
+    private val db = Firebase.firestore
+
+    fun loadPlans() {
+        db.collection("plans").get()
+            .addOnSuccessListener { result ->
+                val list = result.documents.mapNotNull { doc ->
+                    doc.getString("title")?.let { ReadingPlan(it) }
+                }
+                _plans.value = list
+            }
+            .addOnFailureListener {
+                _plans.value = emptyList()
+            }
+    }
+}


### PR DESCRIPTION
## Summary
- document how to use a free cloud database via Firebase Firestore
- load reading plans from Firestore using a new `PlanosViewModel`
- update `PlanosFragment` and `PlansAdapter` to support dynamic plans

## Testing
- `gradle wrapper` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685de586aa5c8327a7375b4d23124cb8