### PR TITLE
Fix navigation drawer navigation handling

### DIFF
--- a/app/src/main/java/br/com/valenstech/letraviva/ui/home/MainActivity.kt
+++ b/app/src/main/java/br/com/valenstech/letraviva/ui/home/MainActivity.kt
@@ -44,9 +44,8 @@ class MainActivity : AppCompatActivity() {
             } else {
                 val handled = NavigationUI.onNavDestinationSelected(menuItem, navController)
                 if (handled) {
-                    menuItem.isChecked = true
+                    drawerLayout.closeDrawer(GravityCompat.START)
                 }
-                drawerLayout.closeDrawer(GravityCompat.START)
                 handled
             }
         }


### PR DESCRIPTION
## Summary
- update the navigation item selection listener in MainActivity to rely on NavigationUI for destination handling
- ensure the drawer only closes after successful navigation so the selected item is properly recognized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d895746308832785304b86cc57e37b