### PR TITLE
Adicionar consumo real de destaques na tela inicial

### DIFF
--- a/app/src/main/java/br/com/valenstech/letraviva/model/DestaquePrincipal.java
+++ b/app/src/main/java/br/com/valenstech/letraviva/model/DestaquePrincipal.java
@@ -1,0 +1,67 @@
+package br.com.valenstech.letraviva.model;
+
+import androidx.annotation.NonNull;
+
+import java.util.Objects;
+
+public class DestaquePrincipal {
+
+    @NonNull
+    private final String id;
+    @NonNull
+    private final String titulo;
+    @NonNull
+    private final String descricao;
+
+    public DestaquePrincipal(@NonNull String id,
+                             @NonNull String titulo,
+                             @NonNull String descricao) {
+        this.id = id;
+        this.titulo = titulo;
+        this.descricao = descricao;
+    }
+
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    @NonNull
+    public String getTitulo() {
+        return titulo;
+    }
+
+    @NonNull
+    public String getDescricao() {
+        return descricao;
+    }
+
+    @Override
+    public boolean equals(Object outro) {
+        if (this == outro) {
+            return true;
+        }
+        if (outro == null || getClass() != outro.getClass()) {
+            return false;
+        }
+        DestaquePrincipal que = (DestaquePrincipal) outro;
+        return id.equals(que.id)
+                && titulo.equals(que.titulo)
+                && descricao.equals(que.descricao);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, titulo, descricao);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "DestaquePrincipal{" +
+                "id='" + id + '\'' +
+                ", titulo='" + titulo + '\'' +
+                ", descricao='" + descricao + '\'' +
+                '}';
+    }
+}

--- a/app/src/main/java/br/com/valenstech/letraviva/repository/RepositorioDestaque.java
+++ b/app/src/main/java/br/com/valenstech/letraviva/repository/RepositorioDestaque.java
@@ -1,0 +1,74 @@
+package br.com.valenstech.letraviva.repository;
+
+import androidx.annotation.NonNull;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import br.com.valenstech.letraviva.model.DestaquePrincipal;
+import br.com.valenstech.letraviva.util.ValidacaoConteudo;
+
+public class RepositorioDestaque {
+
+    @NonNull
+    private final FirebaseFirestore firestore;
+
+    public RepositorioDestaque() {
+        this(FirebaseFirestore.getInstance());
+    }
+
+    public RepositorioDestaque(@NonNull FirebaseFirestore firestore) {
+        this.firestore = firestore;
+    }
+
+    public void buscarDestaquePrincipal(@NonNull final CallbackResultado<DestaquePrincipal> callback) {
+        firestore.collection("highlights")
+                .limit(1)
+                .get()
+                .addOnSuccessListener(snapshot -> {
+                    DocumentSnapshot documento = snapshot.getDocuments().isEmpty() ? null : snapshot.getDocuments().get(0);
+                    if (documento == null) {
+                        callback.aoSucesso(null);
+                        return;
+                    }
+
+                    String descricaoOriginal = documento.getString("description");
+                    if (!ValidacaoConteudo.validarTextoSeguroObrigatorio(descricaoOriginal)) {
+                        callback.aoErro(new IllegalStateException("Descrição do destaque inválida ou insegura."));
+                        return;
+                    }
+
+                    String tituloOriginal = documento.getString("title");
+                    if (!ValidacaoConteudo.validarTextoSeguroOpcional(tituloOriginal)) {
+                        callback.aoErro(new IllegalStateException("Título do destaque contém conteúdo inseguro."));
+                        return;
+                    }
+
+                    String tituloSanitizado = ValidacaoConteudo.sanitizarBasico(tituloOriginal == null ? "" : tituloOriginal);
+                    String descricaoSanitizada = ValidacaoConteudo.sanitizarBasico(descricaoOriginal);
+                    if (descricaoSanitizada.isEmpty()) {
+                        callback.aoErro(new IllegalStateException("Descrição do destaque ausente."));
+                        return;
+                    }
+
+                    String idDocumento = documento.getId();
+                    if (idDocumento == null || idDocumento.trim().isEmpty()) {
+                        callback.aoErro(new IllegalStateException("Identificador do destaque inválido."));
+                        return;
+                    }
+
+                    String idSanitizado = ValidacaoConteudo.sanitizarBasico(idDocumento);
+                    if (idSanitizado.isEmpty()) {
+                        callback.aoErro(new IllegalStateException("Identificador do destaque vazio."));
+                        return;
+                    }
+
+                    DestaquePrincipal destaque = new DestaquePrincipal(
+                            idSanitizado,
+                            tituloSanitizado,
+                            descricaoSanitizada
+                    );
+                    callback.aoSucesso(destaque);
+                })
+                .addOnFailureListener(callback::aoErro);
+    }
+}

--- a/app/src/main/java/br/com/valenstech/letraviva/ui/home/HomeFragment.java
+++ b/app/src/main/java/br/com/valenstech/letraviva/ui/home/HomeFragment.java
@@ -12,15 +12,19 @@ import androidx.lifecycle.ViewModelProvider;
 
 import br.com.valenstech.letraviva.R;
 import br.com.valenstech.letraviva.databinding.FragmentHomeBinding;
+import br.com.valenstech.letraviva.model.DestaquePrincipal;
+import br.com.valenstech.letraviva.util.EstadoUi;
 import br.com.valenstech.letraviva.util.ExtensoesTextView;
 import br.com.valenstech.letraviva.util.ValidacaoConteudo;
 import br.com.valenstech.letraviva.viewmodel.AutenticacaoViewModel;
+import br.com.valenstech.letraviva.viewmodel.HomeViewModel;
 
 public class HomeFragment extends Fragment {
 
     @Nullable
     private FragmentHomeBinding binding;
     private AutenticacaoViewModel autenticacaoViewModel;
+    private HomeViewModel homeViewModel;
 
     @Nullable
     @Override
@@ -46,6 +50,71 @@ public class HomeFragment extends Fragment {
             String nomeSeguro = ValidacaoConteudo.aplicarEscapeSeguro(nomeOriginal);
             ExtensoesTextView.definirTextoSeguro(binding.tvWelcome, getString(R.string.welcome, nomeSeguro));
         });
+
+        homeViewModel = new ViewModelProvider(this).get(HomeViewModel.class);
+        homeViewModel.getEstadoDestaque().observe(getViewLifecycleOwner(), this::processarEstadoDestaque);
+        homeViewModel.carregarDestaque();
+    }
+
+    private void processarEstadoDestaque(@Nullable EstadoUi<DestaquePrincipal> estado) {
+        if (binding == null) {
+            return;
+        }
+        if (estado == null) {
+            mostrarMensagemDestaque(getString(R.string.error_loading_highlight));
+            return;
+        }
+        if (estado instanceof EstadoUi.Carregando) {
+            mostrarCarregamentoDestaque();
+        } else if (estado instanceof EstadoUi.Sucesso) {
+            EstadoUi.Sucesso<DestaquePrincipal> sucesso = (EstadoUi.Sucesso<DestaquePrincipal>) estado;
+            mostrarDestaque(sucesso.getDados());
+        } else if (estado instanceof EstadoUi.Vazio) {
+            EstadoUi.Vazio<DestaquePrincipal> vazio = (EstadoUi.Vazio<DestaquePrincipal>) estado;
+            mostrarMensagemDestaque(vazio.getMensagem());
+        } else if (estado instanceof EstadoUi.Erro) {
+            EstadoUi.Erro<DestaquePrincipal> erro = (EstadoUi.Erro<DestaquePrincipal>) estado;
+            String mensagemErro = erro.getMensagem();
+            if (mensagemErro == null || mensagemErro.trim().isEmpty()) {
+                mensagemErro = getString(R.string.error_loading_highlight);
+            }
+            mostrarMensagemDestaque(mensagemErro);
+        }
+    }
+
+    private void mostrarCarregamentoDestaque() {
+        if (binding == null) {
+            return;
+        }
+        binding.progressHighlight.setVisibility(View.VISIBLE);
+        binding.layoutHighlightConteudo.setVisibility(View.GONE);
+        ExtensoesTextView.definirTextoSeguro(binding.tvHighlightMensagem, getString(R.string.loading_highlight));
+        binding.tvHighlightMensagem.setVisibility(View.VISIBLE);
+    }
+
+    private void mostrarDestaque(@NonNull DestaquePrincipal destaque) {
+        if (binding == null) {
+            return;
+        }
+        binding.progressHighlight.setVisibility(View.GONE);
+        binding.tvHighlightMensagem.setVisibility(View.GONE);
+        binding.layoutHighlightConteudo.setVisibility(View.VISIBLE);
+        boolean tituloVisivel = !destaque.getTitulo().isEmpty();
+        if (tituloVisivel) {
+            ExtensoesTextView.definirTextoSeguro(binding.tvHighlightTitulo, destaque.getTitulo());
+        }
+        binding.tvHighlightTitulo.setVisibility(tituloVisivel ? View.VISIBLE : View.GONE);
+        ExtensoesTextView.definirTextoSeguro(binding.tvHighlightDescricao, destaque.getDescricao());
+    }
+
+    private void mostrarMensagemDestaque(@NonNull String mensagem) {
+        if (binding == null) {
+            return;
+        }
+        binding.progressHighlight.setVisibility(View.GONE);
+        binding.layoutHighlightConteudo.setVisibility(View.GONE);
+        ExtensoesTextView.definirTextoSeguro(binding.tvHighlightMensagem, mensagem);
+        binding.tvHighlightMensagem.setVisibility(View.VISIBLE);
     }
 
     @Override

--- a/app/src/main/java/br/com/valenstech/letraviva/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/br/com/valenstech/letraviva/viewmodel/HomeViewModel.java
@@ -1,0 +1,57 @@
+package br.com.valenstech.letraviva.viewmodel;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import br.com.valenstech.letraviva.R;
+import br.com.valenstech.letraviva.model.DestaquePrincipal;
+import br.com.valenstech.letraviva.repository.CallbackResultado;
+import br.com.valenstech.letraviva.repository.RepositorioDestaque;
+import br.com.valenstech.letraviva.util.EstadoUi;
+
+public class HomeViewModel extends AndroidViewModel {
+
+    @NonNull
+    private final RepositorioDestaque repositorioDestaque;
+    @NonNull
+    private final MutableLiveData<EstadoUi<DestaquePrincipal>> estadoDestaque;
+
+    public HomeViewModel(@NonNull Application aplicacao) {
+        super(aplicacao);
+        repositorioDestaque = new RepositorioDestaque();
+        estadoDestaque = new MutableLiveData<>();
+    }
+
+    @NonNull
+    public LiveData<EstadoUi<DestaquePrincipal>> getEstadoDestaque() {
+        return estadoDestaque;
+    }
+
+    public void carregarDestaque() {
+        estadoDestaque.setValue(new EstadoUi.Carregando<>());
+        repositorioDestaque.buscarDestaquePrincipal(new CallbackResultado<DestaquePrincipal>() {
+            @Override
+            public void aoSucesso(DestaquePrincipal resultado) {
+                if (resultado == null) {
+                    String mensagem = getApplication().getString(R.string.empty_highlight_message);
+                    estadoDestaque.postValue(new EstadoUi.Vazio<>(mensagem));
+                } else {
+                    estadoDestaque.postValue(new EstadoUi.Sucesso<>(resultado));
+                }
+            }
+
+            @Override
+            public void aoErro(@NonNull Exception excecao) {
+                String mensagemErro = excecao.getMessage();
+                if (mensagemErro == null || mensagemErro.trim().isEmpty()) {
+                    mensagemErro = getApplication().getString(R.string.error_loading_highlight);
+                }
+                estadoDestaque.postValue(new EstadoUi.Erro<>(mensagemErro));
+            }
+        });
+    }
+}

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -12,8 +12,50 @@
         android:text="@string/welcome" />
 
     <TextView
-        android:id="@+id/tvHighlight"
+        android:id="@+id/tvHighlightSecao"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/highlight"
+        android:textAppearance="@style/TextAppearance.AppCompat.Title" />
+
+    <ProgressBar
+        android:id="@+id/progressHighlight"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/highlight" />
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="12dp"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/tvHighlightMensagem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:textAlignment="center"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:id="@+id/layoutHighlightConteudo"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/tvHighlightTitulo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.AppCompat.Headline"
+            android:textStyle="bold"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/tvHighlightDescricao"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textSize="16sp" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
     <string name="menu_logout">Sair</string>
     <string name="welcome">Bem-vindo(a), %1$s</string>
     <string name="highlight">Destaques do dia</string>
+    <string name="loading_highlight">Carregando destaques...</string>
+    <string name="empty_highlight_message">Nenhum destaque disponível no momento.</string>
+    <string name="error_loading_highlight">Não foi possível carregar os destaques.</string>
     <string name="listen">Ouvir</string>
     <string name="progress">Progresso</string>
     <string name="default_web_client_id">YOUR_WEB_CLIENT_ID</string>


### PR DESCRIPTION
## Resumo
- carregar o destaque principal da tela inicial diretamente do Firestore
- exibir estados de carregamento, vazio e erro com mensagens sanitizadas
- ajustar o layout da home para substituir textos fixos por conteúdo dinâmico

## Testes
- `./gradlew lint` *(falha: arquivo `gradlew` ausente no repositório)*

------
https://chatgpt.com/codex/tasks/task_e_6900cbb3980483278e0362f8a9e305b2